### PR TITLE
Now grabs resolution from first line of xrandr output

### DIFF
--- a/lock.sh
+++ b/lock.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 TMPBG=/tmp/screen.png
 LOCK=$HOME/lock.png
-RES=$(xrandr | grep '*' | sed -E "s/[^0-9]*([0-9]+)x([0-9]+).*/\1*\2/")
+RES=$(xrandr | grep 'current' | sed -E 's/.*current\s([0-9]+)\sx\s([0-9]+).*/\1x\2/')
  
 ffmpeg -f x11grab -video_size $RES -y -i $DISPLAY -i $LOCK -filter_complex "boxblur=5:1,overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2" -vframes 1 $TMPBG -loglevel quiet
 i3lock -i $TMPBG


### PR DESCRIPTION
On some machines, xrandr output does not mark the current resolution with a *. Grabbing it from the first line I think is more reliable.

(This is my first PR, hope you don't mind)